### PR TITLE
Add disabled class for disabling selects

### DIFF
--- a/semanticUI.coffee
+++ b/semanticUI.coffee
@@ -139,6 +139,7 @@ Template["afSelect_semanticUI"].helpers
   atts: ->
     if @atts.class? then @atts.class += " " else @atts.class = ""
     @atts.class += "ui dropdown"
+    if @atts.disabled? then @atts.class += " disabled"
     @atts
 
 Template["afSelect_semanticUI"].rendered = ->


### PR DESCRIPTION
Semantic UI handles disabling/readonly a bit differently, e.g for selects a "disabled" class is required (as opposed to simply adding a "disabled" attribute). The commit message was a mistake -- I added the disabled option to select inputs only (checkboxes work fine already).

I believe readonly also needs some special handling (e.g a "read-only" class for checkboxes), but I haven't gotten the time to add it yet. 